### PR TITLE
feature: addoptional basic load balancer setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ terraform./
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+.terraform.tfstate.lock.info

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This Terraform script deploys the serverside Google Tag Manager on Cloud Run wit
 - Uptime Check with Notifications - You will be notified if there is an outage of your SGTM services
 - Docker Image Auto Updates - The SGTM Docker image will be updated automatically once per week (default)
 - Log Exculusion - Logs with the serverity default or notice will be excluded to reduce costs
+- Optional basic load balancer setup enabled via setting use_load_balancer variable to true.
 
 ## Getting Started
 ### Quick Start

--- a/main.tf
+++ b/main.tf
@@ -241,6 +241,7 @@ resource "google_cloud_run_v2_service" "gtm_production" {
         stack = "sgtm",
         provider = "mohrstade"
     }
+  deletion_protection = var.deletion_protection
   template {
     annotations = {
       "run.googleapis.com/startup-cpu-boost" = var.cpu_boost

--- a/main.tf
+++ b/main.tf
@@ -186,6 +186,7 @@ resource "google_cloud_run_v2_service" "gtm_preview" {
         stack = "sgtm",
         provider = "mohrstade"
     }
+    deletion_protection = var.deletion_protection
     template {
         annotations = {
           "run.googleapis.com/startup-cpu-boost" = var.cpu_boost

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,5 +1,11 @@
-# Project ID where terraform will build the assests in 
-project_id = "YOUR_GCP_RPOJECT_ID"
+# Name prefix for the resources
+name = "ssgtm"
+
+# Project ID where terraform will build the assests in
+project_id = "terraform-ssgtm-test"
+
+# The project name
+project_name = "terraform-ssgtm-test"
 
 # All resources will be built in this region
 region =  "europe-west3"
@@ -28,7 +34,7 @@ update_interval = "0 8 * * *"
 # The filter to define which logs will be excluded
 cloud_run_exclusion_filter = "resource.type=\"cloud_run_revision\" AND severity = \"INFO\" OR severity =\"DEFAULT\""
 
-# Used for error notfication alerting 
+# Used for error notfication alerting
 notification_users = [
   {
     name  = "USER_NAME_1",
@@ -43,4 +49,9 @@ notification_users = [
 ]
 
 # Used to name the google storage bucket
-google_storage_bucket_name = "RANDOM_STRING"
+google_storage_bucket_name = "ssgtm_bucket"
+
+domain_name = "ssgtm.example.com"
+
+# Do you want to have a load balancer or not
+use_load_balancer = false

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -2,13 +2,13 @@
 name = "ssgtm"
 
 # Project ID where terraform will build the assests in
-project_id = "terraform-ssgtm-test"
+project_id = "PROJECT_ID"
 
 # The project name
-project_name = "terraform-ssgtm-test"
+project_name = "PROJECT_NAME"
 
 # All resources will be built in this region
-region =  "europe-west3"
+region =  "REGION"
 
 # Container Config string from GTM Webinterface
 container_config = "SGTM_CONTAINER_CONFIG"
@@ -49,9 +49,9 @@ notification_users = [
 ]
 
 # Used to name the google storage bucket
-google_storage_bucket_name = "ssgtm_bucket"
+google_storage_bucket_name = "SSGTM_BUCKET_NAME"
 
-domain_name = "ssgtm.example.com"
+domain_name = "SSGTM.EXAMPLE.COM"
 
 # Do you want to have a load balancer or not
 use_load_balancer = false

--- a/variables.tf
+++ b/variables.tf
@@ -96,5 +96,5 @@ variable "name" {
 variable "use_load_balancer" {
   description = "Whether to use a load balancer"
   type        = bool
-  default     = true
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,20 @@ variable "project_id" {
   type        = string
 }
 
+variable "project_name" {
+  description = "The name of the project"
+  type        = string
+}
+
 variable "region" {
   description = "The name of the region to deploy within"
   type        = string
+}
+
+variable "organization_id" {
+  description = "The organization ID for your project"
+  type        = string
+  default     = null  # Set null if not part of an organization
 }
 
 variable "container_config" {
@@ -45,12 +56,12 @@ variable "cpu_boost" {
 
 variable "cloud_function_update_filter" {
   description = "The Cloud function logs when the the Cloud Run SGTM instance gets updated."
-  type = string 
+  type = string
 }
 
 variable "update_interval" {
   description = "Update interval for the Cloud Function updating the SGTM Image in unix-cron job format - Default everyday at 8:00 am UTC"
-  type = string 
+  type = string
 }
 
 variable "cloud_run_exclusion_filter" {
@@ -69,4 +80,21 @@ variable "notification_users" {
 variable "google_storage_bucket_name" {
     description = "The unique name of the google storage bucket"
     type = string
+}
+
+variable "domain_name" {
+  description = "Domain name for the load balancer."
+  type        = string
+  default     = ""
+}
+
+variable "name" {
+  description = "The name of the stack"
+  type        = string
+}
+
+variable "use_load_balancer" {
+  description = "Whether to use a load balancer"
+  type        = bool
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,9 @@ variable "use_load_balancer" {
   type        = bool
   default     = false
 }
+
+ variable "deletion_protection" {
+    description = "Whether to enable deletion protection"
+    type        = bool
+    default     = true
+}


### PR DESCRIPTION
- Feature: Add a basic load balancer setup described as in here: https://cloud.google.com/blog/topics/developers-practitioners/serverless-load-balancing-terraform-hard-way
- Feature: Add all required APIs to start the setup process on a brand-new project
- Fix: Allow running terraform apply multiple times to deploy fixes because of issue and solution described here: https://github.com/hashicorp/terraform-provider-google/issues/3133#issuecomment-468783073

Possible issues:
   - This is missing support for HTTP traffic for now, which also is described in above link
   - this just uses a global forwarding rule that catches and forwards all traffic.